### PR TITLE
Feat/follow unfollow

### DIFF
--- a/src/components/FollowButton.js
+++ b/src/components/FollowButton.js
@@ -1,0 +1,64 @@
+import { useContext, useState } from "react";
+import styled from "styled-components";
+import { UserContext } from "../contexts/UserContext";
+import { postFollowOrUnfollow } from "../services/services";
+
+export default function FollowButton({
+  isFollowed,
+  user_id,
+  callApi,
+  setCallApi,
+}) {
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const { userData } = useContext(UserContext);
+
+  async function followOrUnfollow() {
+    setButtonDisabled(true);
+    const token =
+      JSON.parse(localStorage.getItem("user")).token || userData.token;
+    const followed_id = user_id;
+    const follow_type = isFollowed ? "unfollow" : "follow";
+    try {
+      await postFollowOrUnfollow(token, followed_id, follow_type);
+    } catch (error) {
+      alert(error.message);
+    }
+    setCallApi(callApi + 1);
+    setButtonDisabled(false);
+  }
+  return (
+    <ButtonWrapper
+      disabled={buttonDisabled}
+      isFollowed={isFollowed}
+      onClick={followOrUnfollow}
+    >
+      {isFollowed ? "Unfollow" : "Follow"}
+    </ButtonWrapper>
+  );
+}
+
+const ButtonWrapper = styled.div`
+  background-color: ${(props) => (props.isFollowed ? "#FFFFFF" : "#1877f2")};
+  color: ${(props) => (!props.isFollowed ? "#FFFFFF" : "#1877f2")};
+  pointer-events: ${(props) => (props.disabled ? "none" : "inherit")};
+  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
+  border-radius: 5px;
+  width: 112px;
+  height: 31px;
+  font-family: "Lato";
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 2vh;
+  cursor: pointer;
+
+  @media (max-width: 450px) {
+    left: calc((100vw - 112px) / 2);
+    top: 7vh;
+  }
+`;

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,26 +1,36 @@
 import styled from "styled-components";
 import Post from "./Post";
 import { useEffect, useState, useContext } from "react";
-import { getPostsData } from "../services/services";
+import { getFollowedList, getPostsData } from "../services/services";
 import { UserContext } from "../contexts/UserContext";
 import Publish from "./Publish";
 import HashtagList from "./HashtagsList.js";
 
 export default function Timeline() {
-  const { posts, setPosts, userData, message, setMessage } =
-    useContext(UserContext);
+  const {
+    posts,
+    setPosts,
+    userData,
+    message,
+    setMessage,
+    followedPosts,
+    setFollowedPosts,
+  } = useContext(UserContext);
   const [callApi, setCallApi] = useState(true);
   const userToken =
     JSON.parse(localStorage.getItem("user")).token || userData.token;
   const config = { headers: { Authorization: `Bearer ${userToken}` } };
+  const userId = JSON.parse(localStorage.getItem("user")).user_id;
 
   useEffect(async () => {
     try {
       const response = await getPostsData(config);
-
+      const followed_list = await getFollowedList(userToken);
       if (response.data.length === 0) {
         setMessage("There are no posts yet");
       }
+      let a = response.data.filter((post) => post.user_id === userId);
+      console.log(a);
       setPosts(response.data);
     } catch (error) {
       setMessage(

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -5,11 +5,25 @@ const UserContext = createContext();
 const UserStorage = ({ children }) => {
   const [userData, setUserData] = useState({});
   const [posts, setPosts] = useState([]);
+  const [followedPosts, setFollowedPosts] = useState([]);
   const [message, setMessage] = useState("Loading...");
   const [userId, setUserId] = useState();
 
   return (
-    <UserContext.Provider value={{ userData, setUserData, posts, setPosts, message, setMessage, userId, setUserId }}>
+    <UserContext.Provider
+      value={{
+        userData,
+        setUserData,
+        posts,
+        setPosts,
+        followedPosts,
+        setFollowedPosts,
+        message,
+        setMessage,
+        userId,
+        setUserId,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -92,6 +92,10 @@ function getFollowedList(token) {
   return axios.get(`${baseUrlTest}/followers`, config);
 }
 
+function getUserById(userId) {
+  return axios.get(`${baseUrlTest}/users/${userId}`);
+}
+
 export {
   getPostsData,
   sendLikeOrDeslike,
@@ -107,4 +111,5 @@ export {
   getHashtag,
   postFollowOrUnfollow,
   getFollowedList,
+  getUserById,
 };


### PR DESCRIPTION
- Adicionei a funcionalidade de mostrar apenas os posts próprios e de usuários seguidos na timeline;
- Separei o botão de follow/unfollow em um componente separado para ficar mais legível;
- Corrigi o erro de se utilizar uma rota com um usuário não existente no banco (ex: /users/100).